### PR TITLE
More room for descriptions

### DIFF
--- a/assets/style.less
+++ b/assets/style.less
@@ -65,4 +65,10 @@ body {
       text-align: center;
     }
   }
+
+  .story.no-value {
+    .main-content{
+      height: calc(~"100% - 2em");
+    }
+  }
 }

--- a/assets/style.less
+++ b/assets/style.less
@@ -71,4 +71,18 @@ body {
       height: calc(~"100% - 2em");
     }
   }
+
+  .story.wide {
+    width: 8.5in;
+
+    .description {
+      column-count: 2;
+      -webkit-column-count: 2;
+      -moz-column-count: 2;
+    }
+
+    .points, .value, .roi {
+      width: 8.5in;
+    }
+  }
 }

--- a/assets/style.less
+++ b/assets/style.less
@@ -6,7 +6,7 @@ html {
 }
 body {
   width: 8.5in;
-  
+
   .story {
     position: relative; 
     width: 4.25in;
@@ -27,34 +27,29 @@ body {
       float: left;
       text-align: left;
     }
+
+    .main-content{
+      height: calc(~"100% - 3.2em");
+      overflow: hidden;
+    }
     
     .title {
       font-size: 2em;
-      padding: .5em;
-      height: 3.5em;
+      max-height: 4em;
       overflow: hidden;
     }
-    
-    .description {
-      height: 12em;
-      overflow: hidden;
-    }
-    
-    .bottom {
 
-    }
-    
     .points, .value, .roi {
       position: absolute;
       bottom: 0;
       left: 0;
-      padding: 2em;
-      padding-bottom: 1em;
       width: 4.25in;
+      padding-bottom: 1em;
+      padding-left: 1em;
+      padding-right: 1em;
+      margin: auto;
       h3 {
-        padding-left: .25em;
         display: inline;
-        
       }
     }
     

--- a/assets/template.haml
+++ b/assets/template.haml
@@ -30,3 +30,5 @@
               %h3
                 = story.story_points
       .page-break
+    %script{ :type => "text/javascript",
+             :src => "assets/widen.js" }

--- a/assets/template.haml
+++ b/assets/template.haml
@@ -30,5 +30,6 @@
               %h3
                 = story.story_points
       .page-break
-    %script{ :type => "text/javascript",
-             :src => "assets/widen.js" }
+    - if allow_wide
+      %script{ :type => "text/javascript",
+               :src => "assets/widen.js" }

--- a/assets/template.haml
+++ b/assets/template.haml
@@ -7,7 +7,8 @@
   %body
     - stories.each_slice(6) do |page_stories|
       - page_stories.each do |story|
-        .story
+        - show_value = %w(Story Epic).include?(story.type)
+        .story{:class => ('no-value' unless show_value)}
           .id= story.id
           .type= story.type
           .clearfix
@@ -15,7 +16,7 @@
             .title.text-center= story.title
             .description= story.description
           
-          - if %w(Story Epic).include?(story.type)
+          - if show_value
             .value
               Value:
               %h3

--- a/assets/template.haml
+++ b/assets/template.haml
@@ -11,8 +11,9 @@
           .id= story.id
           .type= story.type
           .clearfix
-          .title.text-center= story.title
-          .description= story.description
+          .main-content
+            .title.text-center= story.title
+            .description= story.description
           
           - if %w(Story Epic).include?(story.type)
             .value

--- a/assets/widen.js
+++ b/assets/widen.js
@@ -1,0 +1,12 @@
+Array.prototype.filter.call(
+  document.querySelectorAll('.main-content'),
+  function(element) {
+    return element.scrollHeight > element.clientHeight;
+  }
+).map(function(element) {
+  return element.closest('.story');
+}).forEach(function(storyElement) {
+  storyElement.classList.add('wide');
+  storyParent = storyElement.parentElement;
+  storyParent.insertBefore(storyElement, storyParent.firstElementChild);
+})

--- a/bin/gen_cards
+++ b/bin/gen_cards
@@ -48,7 +48,7 @@ stories = stories.keep_if do |story|
 end
 
 File.open(OUTPUT, "w") {|f|
-  f.write TEMPLATE.render(Object.new, stories: stories, style: STYLE)
+  f.write TEMPLATE.render(Object.new, stories: stories, style: STYLE, allow_wide: config[:allow_wide])
 }
 
 system "open #{OUTPUT}"

--- a/bin/gen_cards
+++ b/bin/gen_cards
@@ -8,7 +8,7 @@ Bundler.require(:default)
 require_relative '../lib/story'
 
 config = YAML.load_file('config.yml')
-printed = YAML.load_file('.printed') || Hash.new
+printed = YAML.load_file('.printed') rescue Hash.new
 puts printed.inspect
 
 


### PR DESCRIPTION
- Remove some of the internal margins, widen the description area
- Optionally resize cards to double-width with two-columns when description overflows the content area

Branched off of @abull's branch, so also includes his fix
