### PR TITLE
declare UTF-8 encoding

### DIFF
--- a/assets/template.haml
+++ b/assets/template.haml
@@ -1,6 +1,7 @@
 !!!
 %html
   %head
+    %meta{:charset=>'UTF-8'}
   %link{:href=>"http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css", :rel=>"stylesheet"}
   %style
     = style


### PR DESCRIPTION
so CJK characters show up correctly without needing to manually select the encoding in browser
